### PR TITLE
Close #1 - Add icon in search

### DIFF
--- a/packages/react/src/components/DataTable/TableToolbarSearch.js
+++ b/packages/react/src/components/DataTable/TableToolbarSearch.js
@@ -37,6 +37,7 @@ const TableToolbarSearch = ({
   persistant,
   id,
   tabIndex,
+  renderIcon,
   ...rest
 }) => {
   const { current: controlled } = useRef(expandedProp !== undefined);
@@ -114,6 +115,7 @@ const TableToolbarSearch = ({
       className={searchContainerClasses}>
       <Search
         size="sm"
+        renderIcon={renderIcon}
         tabIndex={searchExpanded ? tabIndex : '-1'}
         className={className}
         value={value}
@@ -152,7 +154,6 @@ TableToolbarSearch.propTypes = {
    * Specifies if the search should expand
    */
   expanded: PropTypes.bool,
-
   /**
    * Provide an optional id for the search container
    */
@@ -187,6 +188,11 @@ TableToolbarSearch.propTypes = {
    * Provide an optional placeholder text for the Search component
    */
   placeHolderText: PropTypes.string,
+
+  /**
+     * Optional function to render your own icon in the underlying button
+     */
+    renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
   /**
    * Provide an optional className for the overal container of the Search

--- a/packages/react/src/components/Search/Search.js
+++ b/packages/react/src/components/Search/Search.js
@@ -57,6 +57,10 @@ export default class Search extends Component {
      * VoiceOver on Mac will read both
      */
     placeHolderText: PropTypes.string,
+    /**
+     * Optional function to render your own icon in the underlying button
+     */
+    renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
     /**
      * Specify the search size
@@ -145,6 +149,7 @@ export default class Search extends Component {
       small,
       size = !small ? 'xl' : 'sm',
       light,
+      renderIcon: SearchIconElement,
       ...other
     } = this.props;
 
@@ -166,7 +171,12 @@ export default class Search extends Component {
 
     return (
       <div role="search" aria-labelledby={searchId} className={searchClasses}>
-        <Search16 className={`${prefix}--search-magnifier`} />
+        {!SearchIconElement 
+          ?
+          <Search16 className={`${prefix}--search-magnifier`} />
+          :
+          <SearchIconElement className={`${prefix}--search-magnifier`} />
+        }
         <label id={searchId} htmlFor={id} className={`${prefix}--label`}>
           {labelText}
         </label>

--- a/packages/react/src/components/ToolbarSearch/ToolbarSearch.js
+++ b/packages/react/src/components/ToolbarSearch/ToolbarSearch.js
@@ -50,6 +50,10 @@ export default class ToolbarSearch extends Component {
     placeHolderText: PropTypes.string,
 
     /**
+     * Optional function to render your own icon in the underlying button
+     */
+    renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    /**
      * Optional prop to specify the role of the ToolbarSearch
      */
     role: PropTypes.string,
@@ -111,6 +115,7 @@ export default class ToolbarSearch extends Component {
       labelText,
       role,
       labelId,
+      renderIcon: ToolbarSearchIcon,
       ...other
     } = this.props;
 
@@ -142,10 +147,18 @@ export default class ToolbarSearch extends Component {
             className={`${prefix}--toolbar-search__btn`}
             title={labelText}
             onClick={this.expandSearch}>
+            {!ToolbarSearchIcon
+            ?
             <Search16
               className={`${prefix}--search-magnifier`}
               aria-label={labelText}
             />
+            :
+            <ToolbarSearchIcon
+              className={`${prefix}--search-magnifier`}
+              aria-label={labelText}
+            />
+            }
           </button>
         </div>
       </ClickListener>


### PR DESCRIPTION
Closes #1 

Added the possibility to place your own icon in the Search component. Copied the logic from the Button component.

#### Changelog

**New**

- Added `renderIcon` prop on `Search.js`, `TableToolbarSearch.js` and `ToolbarSearch.js`.
