### PR TITLE
Close #3 - Add custom icon in header button

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "carbon",
   "private": true,
   "version": "0.0.0",
-  "repository": "git@github.com:carbon-design-system/carbon.git",
+  "repository": "git@github.com:theamalgama/carbon.git",
   "license": "Apache-2.0",
   "engines": {
     "node": "12.x"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "carbon-components-react",
+  "name": "@theamalgama/carbon-components-react",
   "description": "The Carbon Design System is IBM’s open-source design system for products and experiences.",
   "version": "7.19.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/carbon-design-system/carbon/tree/master/packages/react",
-  "bugs": "https://github.com/carbon-design-system/carbon/issues",
+  "repository": "https://github.com/theamalgama/carbon",
+  "bugs": "https://github.com/theamalgama/carbon/issues",
   "files": [
     "lib/**/*",
     "es/**/*",

--- a/packages/react/src/components/UIShell/HeaderMenuButton.js
+++ b/packages/react/src/components/UIShell/HeaderMenuButton.js
@@ -22,6 +22,8 @@ const HeaderMenuButton = ({
   onClick,
   isActive,
   isCollapsible,
+  renderIcon: IconElement,
+  renderCloseIcon: CloseIconElement,
   ...rest
 }) => {
   const className = cx({
@@ -45,7 +47,20 @@ const HeaderMenuButton = ({
       title={ariaLabel}
       type="button"
       onClick={onClick}>
-      {isActive ? <Close20 /> : <Menu20 />}
+      {isActive 
+      ? 
+        CloseIconElement
+        ?
+        <CloseIconElement />
+        :
+        <Close20 /> 
+      : 
+        IconElement
+        ?
+        <IconElement />
+        :
+        <Menu20 />
+      }
     </button>
   );
 };
@@ -69,6 +84,14 @@ HeaderMenuButton.propTypes = {
    * button fires it's onclick event
    */
   onClick: PropTypes.func,
+  /**
+    * Optional function to render your own icon in the underlying button
+    */
+  renderCloseIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  /**
+    * Optional function to render your own icon in the underlying button
+    */
+  renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 };
 
 export default HeaderMenuButton;


### PR DESCRIPTION
Closes #3 

**New**

- Add `renderIcon` and `renderCloseIcon` functions to HeaderMenuButton in order to place custom icons for active and inactive state in said button.
