### PR TITLE
Close #6412 - Prevent overflowmenu closing when combox item is clicked.

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -315,6 +315,7 @@ class OverflowMenu extends Component {
   handleClickOutside = (evt) => {
     if (
       this.state.open &&
+      !(evt.target.classList.includes('bx--list-box__menu-item__option')) &&
       (!this._menuBody || !this._menuBody.contains(evt.target))
     ) {
       this.closeMenu();


### PR DESCRIPTION
Closes #6412

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
